### PR TITLE
Update to new DSF implementation

### DIFF
--- a/abcd.c
+++ b/abcd.c
@@ -1211,7 +1211,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/ascent.c
+++ b/ascent.c
@@ -2208,7 +2208,7 @@ static const char *decode_ui_item(int *arr, int s, char stop, const char *p)
 	return p;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 	if(!encoding || encoding[0] != 'P') return;
 	

--- a/boats.c
+++ b/boats.c
@@ -1194,7 +1194,7 @@ static char boats_validate_gridclues(const game_state *state, int *errs)
 	return ret;
 }
 
-static char boats_check_dsf(game_state *state, int *dsf, int *fleetcount)
+static char boats_check_dsf(game_state *state, DSF *dsf, int *fleetcount)
 {
 	/* 
 	 * Build a dsf of all unfinished boats. Finished boats, water and empty
@@ -1209,7 +1209,7 @@ static char boats_check_dsf(game_state *state, int *dsf, int *fleetcount)
 	char ret = STATUS_COMPLETE;
 	
 	memcpy(tempfleet, fleetcount, sizeof(int)*state->fleet);
-	dsf_init(dsf, (w*h)+1);
+	dsf_reinit(dsf);
 	for(y = 0; y < h; y++)
 	for(x = 0; x < w; x++)
 	{
@@ -1263,7 +1263,7 @@ static char boats_check_dsf(game_state *state, int *dsf, int *fleetcount)
 	return ret;
 }
 
-static char boats_validate_full_state(game_state *state, int *blankcounts, int *shipcounts, int *fleetcount, int *dsf)
+static char boats_validate_full_state(game_state *state, int *blankcounts, int *shipcounts, int *fleetcount, DSF *dsf)
 {
 	/*
 	 * Check if the current state is complete, incomplete, or contains errors.
@@ -1715,7 +1715,7 @@ static int boats_solver_centers_normal(game_state *state, int *shipcounts)
 	return ret;
 }
 
-static int boats_solver_min_expand_dsf_forward(game_state *state, int *fleetcount, int *dsf,
+static int boats_solver_min_expand_dsf_forward(game_state *state, int *fleetcount, DSF *dsf,
 		int sx, int sy, int d, int ship)
 {
 	/*
@@ -1751,7 +1751,7 @@ static int boats_solver_min_expand_dsf_forward(game_state *state, int *fleetcoun
 	return 0;
 }
 
-static int boats_solver_min_expand_dsf_back(game_state *state, int *fleetcount, int *dsf,
+static int boats_solver_min_expand_dsf_back(game_state *state, int *fleetcount, DSF *dsf,
 		int d, int ship)
 {
 	/*
@@ -1787,7 +1787,7 @@ static int boats_solver_min_expand_dsf_back(game_state *state, int *fleetcount, 
 	return 0;
 }
 
-static int boats_solver_min_expand_dsf(game_state *state, int *fleetcount, int *dsf)
+static int boats_solver_min_expand_dsf(game_state *state, int *fleetcount, DSF *dsf)
 {
 	/*
 	 * See if an unfinished boat needs to expand in the last possible direction.
@@ -1817,7 +1817,7 @@ static int boats_solver_min_expand_dsf(game_state *state, int *fleetcount, int *
 	return 0;
 }
 
-static int boats_solver_max_expand_dsf(game_state *state, int *fleetcount, int *dsf)
+static int boats_solver_max_expand_dsf(game_state *state, int *fleetcount, DSF *dsf)
 {
 	/* 
 	 * See if an unfinished boat becomes too large when expanding into
@@ -2497,7 +2497,7 @@ static int boats_solve_game(game_state *state, int maxdiff)
 	
 	struct boats_run *runs = NULL;
 	char *tmpgrid = NULL;
-	int *dsf = NULL;
+	DSF *dsf = NULL;
 	int runcount = 0;
 	int *borderclues = NULL;
 	int diff = DIFF_EASY;
@@ -2521,7 +2521,7 @@ static int boats_solve_game(game_state *state, int maxdiff)
 	{
 		runs = snewn(w*h*2, struct boats_run);
 		
-		dsf = snewn((w*h)+1, int);
+		dsf = dsf_new((w*h)+1);
 	}
 	
 	for(i = 0; i < w+h && !hasnoclue; i++)
@@ -2651,7 +2651,7 @@ static int boats_solve_game(game_state *state, int maxdiff)
 	sfree(runs);
 	sfree(tmpgrid);
 	sfree(borderclues);
-	sfree(dsf);
+	dsf_free(dsf);
 	
 	return diff;
 }
@@ -3112,7 +3112,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/bricks.c
+++ b/bricks.c
@@ -952,7 +952,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/clusters.c
+++ b/clusters.c
@@ -658,7 +658,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/crossing.c
+++ b/crossing.c
@@ -934,7 +934,7 @@ static bool crossing_gen_walls_checkpool(int w, int h, char *walls)
 
 static bool crossing_gen_walls_checkdsf(int w, int h, char *walls)
 {
-	int *dsf = snew_dsf(w*h);
+	DSF *dsf = dsf_new(w*h);
 	int i, s, i1, i2, x, y;
 	int maxsize, maxcell, total;
 	
@@ -978,7 +978,7 @@ static bool crossing_gen_walls_checkdsf(int w, int h, char *walls)
 			maxcell = dsf_canonify(dsf, i);
 		}
 	}
-	sfree(dsf);
+	dsf_free(dsf);
 	return maxsize == total;
 }
 
@@ -1242,7 +1242,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/mathrax.c
+++ b/mathrax.c
@@ -1117,7 +1117,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/rome.c
+++ b/rome.c
@@ -105,7 +105,7 @@ struct game_state {
 	int w, h;
 	
 	/* region layout */
-	int *dsf;
+	DSF *dsf;
 	
 	cell *grid;
 	cell *marks;
@@ -261,7 +261,7 @@ static const char *validate_params(const game_params *params, bool full)
 
 static void free_game(game_state *state)
 {
-	sfree(state->dsf);
+	dsf_free(state->dsf);
 	sfree(state->grid);
 	sfree(state->marks);
 	sfree(state);
@@ -274,7 +274,7 @@ static void free_game(game_state *state)
 enum { STATUS_COMPLETE, STATUS_INCOMPLETE, STATUS_INVALID };
 enum { VALID, INVALID_WALLS, INVALID_CLUES, INVALID_REGIONS, INVALID_GOALS };
 
-static char rome_validate_game(game_state *state, bool fullerrors, int *dsf, cell *sets)
+static char rome_validate_game(game_state *state, bool fullerrors, DSF *dsf, cell *sets)
 {
 	int w = state->w;
 	int h = state->h;
@@ -288,8 +288,8 @@ static char rome_validate_game(game_state *state, bool fullerrors, int *dsf, cel
 		state->grid[i] &= ~(FE_MASK|FD_TOGOAL);
 	
 	if(!hasdsf)
-		dsf = snewn(w*h, int);
-	dsf_init(dsf, w*h);
+		dsf = dsf_new_min(w*h);
+	dsf_reinit(dsf);
 	if(!hassets)
 		sets = snewn(w*h, cell);
 	seterrs = snewn(w*h, cell);
@@ -397,10 +397,10 @@ static char rome_validate_game(game_state *state, bool fullerrors, int *dsf, cel
 		{
 			if(state->grid[i] & FM_GOAL)
 			{
-				c = dsf_canonify(dsf, i);
+				c = dsf_minimal(dsf, i);
 				for(x = c; x < w*h; x++)
 				{
-					if(c == dsf_canonify(dsf, x))
+					if(c == dsf_minimal(dsf, x))
 						state->grid[x] |= FD_TOGOAL;
 				}
 			}
@@ -408,7 +408,7 @@ static char rome_validate_game(game_state *state, bool fullerrors, int *dsf, cel
 	}
 	
 	if(!hasdsf)
-		sfree(dsf);
+		dsf_free(dsf);
 	if(!hassets)
 		sfree(sets);
 	sfree(seterrs);
@@ -439,7 +439,7 @@ static int rome_read_desc(const game_params *params, const char *desc, game_stat
 	
 	state->w = w;
 	state->h = h;
-	state->dsf = snew_dsf(w*h);
+	state->dsf = dsf_new_min(w*h);
 	
 	state->completed = state->cheated = false;
 	
@@ -619,14 +619,14 @@ static game_state *dup_game(const game_state *state)
 
 	ret->w = w;
 	ret->h = h;
-	ret->dsf = snewn(w*h, int);
+	ret->dsf = dsf_new_min(w*h);
 	ret->grid = snewn(w*h, cell);
 	ret->marks = snewn(w*h, cell);
 	
 	ret->completed = state->completed;
 	ret->cheated = state->cheated;
 
-	memcpy(ret->dsf, state->dsf, w*h*sizeof(int));
+	dsf_copy(ret->dsf, state->dsf);
 	memcpy(ret->grid, state->grid, w*h*sizeof(cell));
 	memcpy(ret->marks, state->marks, w*h*sizeof(cell));
 	
@@ -695,7 +695,7 @@ static int rome_solver_doubles(game_state *state, cell *sets)
 	return ret;
 }
 
-static int rome_solver_loops(game_state *state, int *dsf)
+static int rome_solver_loops(game_state *state, DSF *dsf)
 {
 	/* Find nearby squares that would form a loop */
 	int w = state->w;
@@ -828,7 +828,7 @@ static int rome_naked_pairs(game_state *state)
 	return ret;
 }
 
-static int rome_solver_expand(game_state *state, int *dsf)
+static int rome_solver_expand(game_state *state, DSF *dsf)
 {
 	/* Check if there is one single possibility to expand the area pointing
 	   to a goal. */
@@ -966,7 +966,7 @@ static char rome_solve(game_state *state, int maxdiff)
 	int i;
 	char status;
 	
-	int *dsf = snewn(w*h, int);
+	DSF *dsf = dsf_new_min(w*h);
 	cell *sets = snewn(w*h, cell);
 	
 	/* Initialize all marks */
@@ -1026,7 +1026,7 @@ static char rome_solve(game_state *state, int maxdiff)
 		break;
 	}
 	
-	sfree(dsf);
+	dsf_free(dsf);
 	sfree(sets);
 	
 	return status;
@@ -1067,7 +1067,7 @@ static char *solve_game(const game_state *state, const game_state *currstate,
  * Generator *
  * ********* */
  
-static void rome_join_arrows(game_state *state, int *arrdsf, cell *suggest)
+static void rome_join_arrows(game_state *state, DSF *arrdsf, cell *suggest)
 {
 	/*
 	 * This function detects clusters of identical arrows, and gives
@@ -1126,7 +1126,7 @@ static bool rome_generate_arrows(game_state *state, random_state *rs)
 	int i, j, k;
 	
 	int *spaces = snewn(w*h, int);
-	int *arrdsf = snew_dsf(w*h);
+	DSF *arrdsf = dsf_new_min(w*h);
 	cell *suggest = snewn(w*h, cell);
 	
 	cell *arrows = snewn(4, cell);
@@ -1179,7 +1179,7 @@ static bool rome_generate_arrows(game_state *state, random_state *rs)
 	}
 	
 	sfree(spaces);
-	sfree(arrdsf);
+	dsf_free(arrdsf);
 	sfree(suggest);
 	sfree(arrows);
 	
@@ -1360,13 +1360,13 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 	
 	state->w = w;
 	state->h = h;
-	state->dsf = snewn(w*h, int);
+	state->dsf = dsf_new_min(w*h);
 	state->grid = snewn(w*h, cell);
 	state->marks = snewn(w*h, cell);
 	
 	do
 	{
-		dsf_init(state->dsf, w*h);
+		dsf_reinit(state->dsf);
 		memset(state->grid, EMPTY, w*h*sizeof(cell));
 		memset(state->marks, EMPTY, w*h*sizeof(cell));
 	} while(!rome_generate(state, rs, params->diff));
@@ -1522,7 +1522,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 
@@ -1979,7 +1979,7 @@ static void game_redraw(drawing *dr, game_drawstate *ds, const game_state *oldst
 	int h = state->h;
 	int x, y, i1, i2, cx, cy, cw, ch;
 	int tilesize = ds->tilesize;
-	int *dsf = state->dsf;
+	DSF *dsf = state->dsf;
 	int color;
 	int kmode = ui->kmode;
 	cell c, p;

--- a/salad.c
+++ b/salad.c
@@ -1446,7 +1446,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/spokes.c
+++ b/spokes.c
@@ -447,7 +447,7 @@ struct spokes_scratch {
 	int *lines;
 	int *marked;
 	
-	int *dsf;
+	DSF *dsf;
 	int *open;
 };
 
@@ -491,7 +491,7 @@ static void spokes_solver_recount(const game_state *state, struct spokes_scratch
 		}
 	}
 	
-	dsf_init(solver->dsf, w*h);
+	dsf_reinit(solver->dsf);
 	
 	/* If the top-left square is empty, connect it to the first non-empty square. */
 	if(!state->numbers[0])
@@ -674,7 +674,7 @@ static struct spokes_scratch *spokes_new_scratch(const game_state *state)
 	solver->nodes = snewn(w*h, int);
 	solver->lines = snewn(w*h, int);
 	solver->marked = snewn(w*h, int);
-	solver->dsf = snewn(w*h, int);
+	solver->dsf = dsf_new(w*h);
 	solver->open = snewn(w*h, int);
 	
 	return solver;
@@ -685,7 +685,7 @@ static void spokes_free_scratch(struct spokes_scratch *solver)
 	sfree(solver->nodes);
 	sfree(solver->lines);
 	sfree(solver->marked);
-	sfree(solver->dsf);
+	dsf_free(solver->dsf);
 	sfree(solver->open);
 	sfree(solver);
 }
@@ -1096,7 +1096,7 @@ static char *encode_ui(const game_ui *ui)
     return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/sticks.c
+++ b/sticks.c
@@ -225,7 +225,7 @@ static const char *validate_params(const game_params *params, bool full)
 
 enum { STATUS_COMPLETE, STATUS_UNFINISHED, STATUS_INVALID };
 
-static void sticks_make_dsf(game_state *state, int *dsf, int *lengths)
+static void sticks_make_dsf(game_state *state, DSF *dsf, int *lengths)
 {
 	int w = state->w, h = state->h;
 	int x, y, i;
@@ -235,7 +235,7 @@ static void sticks_make_dsf(game_state *state, int *dsf, int *lengths)
 			lengths[i] = -1;
 	}
 	
-	dsf_init(dsf, w*h);
+	dsf_reinit(dsf);
 	
 	for(y = 0; y < h; y++)
 	for(x = 0; x < w; x++)
@@ -261,7 +261,7 @@ static void sticks_make_dsf(game_state *state, int *dsf, int *lengths)
 	}
 }
 
-static int sticks_max_size_horizontal(game_state *state, int *dsf, int *lengths, int idx)
+static int sticks_max_size_horizontal(game_state *state, DSF *dsf, int *lengths, int idx)
 {
 	int w = state->w;
 	int c, x, y = idx / w;
@@ -302,7 +302,7 @@ static int sticks_max_size_horizontal(game_state *state, int *dsf, int *lengths,
 	return ret;
 }
 
-static int sticks_max_size_vertical(game_state *state, int *dsf, int *lengths, int idx)
+static int sticks_max_size_vertical(game_state *state, DSF *dsf, int *lengths, int idx)
 {
 	int w = state->w, h = state->h;
 	int c, y, x = idx%w;
@@ -343,7 +343,7 @@ static int sticks_max_size_vertical(game_state *state, int *dsf, int *lengths, i
 	return ret;
 }
 
-static int sticks_validate(game_state *state, int *dsf, int *lengths)
+static int sticks_validate(game_state *state, DSF *dsf, int *lengths)
 {
 	int w = state->w, h = state->h;
 	int x, y, i;
@@ -351,7 +351,7 @@ static int sticks_validate(game_state *state, int *dsf, int *lengths)
 	bool hastemp = dsf != NULL;
 	if (!hastemp)
 	{
-		dsf = snewn(w*h, int);
+		dsf = dsf_new(w*h);
 		lengths = snewn(w*h, int);
 	}
 	bool error;
@@ -429,7 +429,7 @@ static int sticks_validate(game_state *state, int *dsf, int *lengths)
 
 	if (!hastemp)
 	{
-		sfree(dsf);
+		dsf_free(dsf);
 		sfree(lengths);
 	}
 	return ret;
@@ -545,7 +545,7 @@ static void free_game(game_state *state)
 	sfree(state);
 }
 
-static int sticks_try(game_state *state, int *dsf, int *lengths)
+static int sticks_try(game_state *state, DSF *dsf, int *lengths)
 {
 	int s = state->w * state->h;
 	int i;
@@ -580,7 +580,7 @@ static int sticks_solve_game(game_state *state)
 	int i;
 	int ret = STATUS_UNFINISHED;
 
-	int *dsf = snewn(s, int);
+	DSF *dsf = dsf_new(s);
 	int *lengths = snewn(s, int);
 
 	for (i = 0; i < s; i++)
@@ -597,7 +597,7 @@ static int sticks_solve_game(game_state *state)
 		break;
 	}
 
-	sfree(dsf);
+	dsf_free(dsf);
 	sfree(lengths);
 	return ret;
 }
@@ -719,7 +719,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 			   char **aux, bool interactive)
 {
 	int w = params->w, h = params->h;
-	int *dsf = snewn(w*h, int);
+	DSF *dsf = dsf_new(w*h);
 	int *spaces = snewn(w*h, int);
 	int i, j;
 	game_state *state = new_game(NULL, params, NULL);
@@ -754,14 +754,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 			}
 			else if (dsf_canonify(dsf, i) == i)
 			{
-				int n = dsf_size(dsf, i);
-
-				if (n == 1)
-					state->numbers[i] = 1;
-				else if (state->grid[i] & F_HOR)
-					state->numbers[i + random_upto(rs, n)] = n;
-				else if (state->grid[i] & F_VER)
-					state->numbers[i + (w*random_upto(rs, n))] = n;
+				state->numbers[i] = dsf_size(dsf, i);
 			}
 		}
 	} while (sticks_solve_game(state) != STATUS_COMPLETE);
@@ -822,7 +815,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 	*p++ = '\0';
 	ret = sresize(ret, p - ret, char);
 	free_game(state);
-	sfree(dsf);
+	dsf_free(dsf);
 	sfree(spaces);
 
 	return ret;
@@ -893,7 +886,7 @@ static char *encode_ui(const game_ui *ui)
 	return NULL;
 }
 
-static void decode_ui(game_ui *ui, const char *encoding)
+static void decode_ui(game_ui *ui, const char *encoding, const game_state *state)
 {
 }
 

--- a/sticks.c
+++ b/sticks.c
@@ -351,7 +351,7 @@ static int sticks_validate(game_state *state, DSF *dsf, int *lengths)
 	bool hastemp = dsf != NULL;
 	if (!hastemp)
 	{
-		dsf = dsf_new(w*h);
+		dsf = dsf_new_min(w*h);
 		lengths = snewn(w*h, int);
 	}
 	bool error;
@@ -580,7 +580,7 @@ static int sticks_solve_game(game_state *state)
 	int i;
 	int ret = STATUS_UNFINISHED;
 
-	DSF *dsf = dsf_new(s);
+	DSF *dsf = dsf_new_min(s);
 	int *lengths = snewn(s, int);
 
 	for (i = 0; i < s; i++)
@@ -719,7 +719,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 			   char **aux, bool interactive)
 {
 	int w = params->w, h = params->h;
-	DSF *dsf = dsf_new(w*h);
+	DSF *dsf = dsf_new_min(w*h);
 	int *spaces = snewn(w*h, int);
 	int i, j;
 	game_state *state = new_game(NULL, params, NULL);
@@ -752,9 +752,16 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 				if (i / w < h - 1 && state->grid[i + w] & F_VER) n++;
 				state->numbers[i] = n;
 			}
-			else if (dsf_canonify(dsf, i) == i)
+			else if (dsf_minimal(dsf, i) == i)
 			{
-				state->numbers[i] = dsf_size(dsf, i);
+				int n = dsf_size(dsf, i);
+
+				if (n == 1)
+					state->numbers[i] = 1;
+				else if (state->grid[i] & F_HOR)
+					state->numbers[i + random_upto(rs, n)] = n;
+				else if (state->grid[i] & F_VER)
+					state->numbers[i + (w*random_upto(rs, n))] = n;
 			}
 		}
 	} while (sticks_solve_game(state) != STATUS_COMPLETE);


### PR DESCRIPTION
Simon Tatham rewrote the DSF implementation. Mostly straightforward search-and-replace changes, but a few puzzles needed extra tweaks:
 - Rome uses `dsf_new_min` so that "Mark arrows pointing at a goal" can use `dsf_minimal` instead of `dsf_canonify`, which is no longer guaranteed to return the "smallest element of the equivalence class in the dsf containing `val`"
 - ~~In Sticks, since `dsf_canonify` is no longer guaranteed to be the minimal element, there's no longer a need for the logic that included `random_upto`~~ [updated: see later comments]
 - The deleted `memset` line in Seismic breaks with the new DSF struct. I'm not sure if it was necessary in the first place...?

Also at some point the method signature for `decode_ui` changed, so I included fixes for those compiler warnings.