### PR TITLE
Fix ascent

### DIFF
--- a/ascent.c
+++ b/ascent.c
@@ -1743,7 +1743,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 	enum { RUN_NONE, RUN_BLANK, RUN_WALL, RUN_NUMBER } runtype = RUN_NONE;
 	for(i = 0; i <= w*h; i++)
 	{
-		n = grid[i];
+		n = (i == w*h) ? -1 : grid[i];
 		if(IS_NUMBER_EDGE(n)) n = NUMBER_EDGE(n);
 
 		if(runtype == RUN_BLANK && (i == w*h || n != NUMBER_EMPTY))
@@ -3782,7 +3782,7 @@ static void game_redraw(drawing *dr, game_drawstate *ds,
 					FONT_VARIABLE, tilesize/2, ALIGN_HCENTRE|ALIGN_VCENTRE,
 					GET_BIT(state->immutable, i) ? COL_IMMUTABLE : 
 					state->grid[i] == NUMBER_EMPTY && ui->typing_cell != i ? COL_LOWLIGHT :
-					n <= state->last && positions[n] == CELL_MULTIPLE && ui->typing_cell != i ? COL_ERROR :
+					n >= 0 && n <= state->last && positions[n] == CELL_MULTIPLE && ui->typing_cell != i ? COL_ERROR :
 					COL_BORDER, buf);
 			
 			if(ds->path[i] & FLAG_ERROR)

--- a/ascent.c
+++ b/ascent.c
@@ -1743,7 +1743,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 	enum { RUN_NONE, RUN_BLANK, RUN_WALL, RUN_NUMBER } runtype = RUN_NONE;
 	for(i = 0; i <= w*h; i++)
 	{
-		n = (i == w*h) ? -1 : grid[i];
+		n = (i == w*h) ? NUMBER_EMPTY : grid[i];
 		if(IS_NUMBER_EDGE(n)) n = NUMBER_EDGE(n);
 
 		if(runtype == RUN_BLANK && (i == w*h || n != NUMBER_EMPTY))
@@ -3782,7 +3782,7 @@ static void game_redraw(drawing *dr, game_drawstate *ds,
 					FONT_VARIABLE, tilesize/2, ALIGN_HCENTRE|ALIGN_VCENTRE,
 					GET_BIT(state->immutable, i) ? COL_IMMUTABLE : 
 					state->grid[i] == NUMBER_EMPTY && ui->typing_cell != i ? COL_LOWLIGHT :
-					n >= 0 && n <= state->last && positions[n] == CELL_MULTIPLE && ui->typing_cell != i ? COL_ERROR :
+					n <= state->last && positions[n] == CELL_MULTIPLE && ui->typing_cell != i ? COL_ERROR :
 					COL_BORDER, buf);
 			
 			if(ds->path[i] & FLAG_ERROR)

--- a/bricks.c
+++ b/bricks.c
@@ -247,7 +247,7 @@ static char bricks_validate_threes(int w, int h, cell *grid)
 
 	/* Check for any three in a row, and mark errors accordingly */
 	for (y = 0; y < h; y++) {
-		for (x = 0; x < w; x++) {
+		for (x = 1; x < w-1; x++) {
 			int i1 = y * w + x-1;
 			int i2 = y * w + x;
 			int i3 = y * w + x+1;
@@ -641,7 +641,7 @@ static char *solve_game(const game_state *state, const game_state *currstate,
 	cell n;
 	int result;
 
-	bricks_solve_game(solved, DIFF_TRICKY, NULL, true, false);
+	bricks_solve_game(solved, DIFF_TRICKY, NULL, true, true);
 
 	result = bricks_validate(w, h, solved->grid, false);
 
@@ -734,10 +734,10 @@ static void bricks_fill_grid(game_state *state, random_state *rs)
 			int i2 = (y+1) * w + x-1;
 			int i3 = (y+1) * w + x;
 
-			cell n2 = x == 0 ? F_BOUND : state->grid[i2];
+			cell n2 = (x == 0 || y == h-1) ? F_BOUND : state->grid[i2];
 			if(!(n2 & F_BOUND))
 				n2 &= COL_MASK;
-			cell n3 = state->grid[i3];
+			cell n3 = (y == h-1) ? F_BOUND : state->grid[i3];
 			if(!(n3 & F_BOUND))
 				n3 &= COL_MASK;
 
@@ -865,7 +865,7 @@ static char *new_game_desc(const game_params *params, random_state *rs,
 	enum { RUN_NONE, RUN_BLANK, RUN_NUMBER } runtype = RUN_NONE;
 	for(i = 0; i <= w*h; i++)
 	{
-		n = state->grid[i];
+		n = (i == w*h) ? 0 : state->grid[i];
 
 		if(runtype == RUN_BLANK && (i == w*h || !(n & COL_MASK)))
 		{
@@ -1059,7 +1059,7 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 			if(buf[0])
 				return dupstr(buf);
 		}
-		return UI_UPDATE;
+		return MOVE_UI_UPDATE;
 	}
 
 	oy -= ds->offsety;
@@ -1081,7 +1081,7 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 			ui->cshow = false;
 		}
 		else
-			return NULL;
+			return MOVE_NO_EFFECT;
 	}
 
 	if (IS_MOUSE_DOWN(button))
@@ -1101,7 +1101,7 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 		if (ui->dragtype || old)
 			ui->drag[ui->ndrags++] = i;
 
-		return UI_UPDATE;
+		return MOVE_UI_UPDATE;
 	}
 
 	if (IS_MOUSE_DRAG(button) && ui->dragtype)
@@ -1110,17 +1110,17 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 		int d;
 
 		if (state->grid[i] == ui->dragtype)
-			return NULL;
+			return MOVE_NO_EFFECT;
 
 		for (d = 0; d < ui->ndrags; d++)
 		{
 			if (i == ui->drag[d])
-				return NULL;
+				return MOVE_NO_EFFECT;
 		}
 
 		ui->drag[ui->ndrags++] = i;
 
-		return UI_UPDATE;
+		return MOVE_UI_UPDATE;
 	}
 
 	if (IS_MOUSE_RELEASE(button) && ui->ndrags)
@@ -1145,7 +1145,7 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 			return buf;
 		
 		sfree(buf);
-		return UI_UPDATE;
+		return MOVE_UI_UPDATE;
 	}
 
 	/* Place one */
@@ -1158,7 +1158,7 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 		cell old = state->grid[i] & COL_MASK;
 
 		if (!old)
-			return NULL;
+			return MOVE_NO_EFFECT;
 
 		c = 'C';
 
@@ -1176,14 +1176,14 @@ static char *interpret_move(const game_state *state, game_ui *ui,
 		if ((old == F_SHADE && c == 'A') ||
 			(old == F_UNSHADE && c == 'B') ||
 			(old == F_EMPTY && c == 'C'))
-			return NULL;               /* don't put no-ops on the undo chain */
+			return MOVE_NO_EFFECT;               /* don't put no-ops on the undo chain */
 
 		sprintf(buf, "%c%d;", c, i);
 
 		return dupstr(buf);
 	}
 
-	return NULL;
+	return MOVE_UNUSED;
 }
 
 static game_state *execute_move(const game_state *state, const char *move)


### PR DESCRIPTION
This pull request should solve similiar problems like in bricks:

a) Set `n = -1` when `i == w*h` in `new_game_desc`, as n is not needed for this condition, to avoid invalid access.
b) `n` can get negative in `game_redraw`, causing negative index access to `*positions`. Add extra check for n to be non-negative.